### PR TITLE
Tweak README to make variable clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ server {
 The first time you run this it needs to create a key, you can trigger that using:
 
 ```
-docker-compose run --rm cli config {relayHost}
+docker-compose run --rm cli config ${RELAY_HOST}
 ```
 
 If you want requests to the homepage to redirect visitors somewhere, you can add a `"HomeRedirect"` entry on the generated `config.json`. The file would look like this:


### PR DESCRIPTION
Currently it's not super clear if `{relayHost}` is some kind of placeholder that will be substituted under the hood, or intended to be a placeholder that the user needs to adjust before they run the command.

Changing it to a shell var should disambiguate, and also mean that running the command verbatim produces an error, instead of resulting in an invalid configuration.