### PR TITLE
Add support for logging for debug purposes

### DIFF
--- a/src/FakeRelay.Web/Program.cs
+++ b/src/FakeRelay.Web/Program.cs
@@ -39,6 +39,8 @@ if (!app.Environment.IsDevelopment())
     app.UseHsts();
 }
 
+app.UseHttpLogging();
+
 app.UseHttpsRedirection();
 
 app.UseRouting();


### PR DESCRIPTION
To make it easiser to test if the FakeRelay works it would be great if we could see the HTTP requests received by it.

By default no log messages will be shown.

To show log messages set the environment variable `Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware` to `Information`.